### PR TITLE
add option to use unicast packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ http:
           macAddress: 00:00:00:00:00:00 # REQUIRED The MAC address of the machine to start
           ipAddress: 192.168.0.1 # The network appliance replaying the magic packet
 ```
+Another example but with [WoL SDB](https://en.wikipedia.org/wiki/Wake-on-LAN#Subnet_directed_broadcasts):
+```yaml
+http:
+  middlewares:
+    traefik-wol:
+      plugin:
+        wol:
+          healthCheck: http://192.168.0.10:8009 # REQUIRED The URL to use for the health check
+          macAddress: 00:00:00:00:00:00 # REQUIRED The MAC address of the machine to start
+          ipAddress: 192.168.0.255 # The Broadcast address of the targeted network
+```
+
 
 ### Using an external wake-on-lan service
 In order to not have to run the plugin in `host` mode, or configuring a network appliance to replay your packets, you can use an external wake-on-lan service.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Traefik plugin which starts a machine when a request is received using wake-on-l
 Based somewhat on [`go-wol`](https://github.com/sabhiram/go-wol).
 
 ## Operation modes
-### Using the built-in wake-on-lan service
+### Using the built-in wake-on-lan service with a braodcast
 
-In this mode, the plugin will try to start the machine using the wake-on-lan service provided by the plugin.
+In this mode, the plugin will try to start the machine using the wake-on-lan service via broadcast provided by the plugin.
 For this to work, the plugin needs to be able to send a magic packet to the machine.
 This means that the machine needs to be on the same network as the plugin.
 In other words, when using docker the network mode needs to be `host`.
@@ -20,11 +20,30 @@ http:
         wol:
           healthCheck: http://192.168.0.10:8009 # REQUIRED The URL to use for the health check
           macAddress: 00:00:00:00:00:00 # REQUIRED The MAC address of the machine to start
-          ipAddress: 192.168.0.10 # REQUIRED The IP address of the machine to start
+```
+
+### Using the built-in wake-on-lan service via unicast
+In this mode, the plugin will try to start the machine using the wake-on-lan service via unicast provided by the plugin.
+For this to work, the ipAddress targeted, usually a router, or firewall, needs to be configured to replay the magic packet to the correct interface in the network.
+Configuring a broadcast-relay or dnat on udp port 9, should do the trick.
+- [Broadcast-relay on vyos](https://docs.vyos.io/en/latest/configuration/service/broadcast-relay.html)
+- [Destination NAT on opnsense](https://docs.opnsense.org/manual/nat.html#destination-nat-port-forward)
+
+This is especially helpful when you use traefik as ingress in kubernetes, or want to wake a pc in another network, like a branch office.
+Example:
+```yaml
+http:
+  middlewares:
+    traefik-wol:
+      plugin:
+        wol:
+          healthCheck: http://192.168.0.10:8009 # REQUIRED The URL to use for the health check
+          macAddress: 00:00:00:00:00:00 # REQUIRED The MAC address of the machine to start
+          ipAddress: 192.168.0.1 # The network appliance replaying the magic packet
 ```
 
 ### Using an external wake-on-lan service
-In order to not have to run the plugin in `host` mode, you can use an external wake-on-lan service.
+In order to not have to run the plugin in `host` mode, or configuring a network appliance to replay your packets, you can use an external wake-on-lan service.
 This service needs to be able to send a magic packet to the machine.
 The plugin will then send a request to the service to start the machine.
 

--- a/wol.go
+++ b/wol.go
@@ -3,12 +3,13 @@ package traefik_wol
 import (
 	"context"
 	"fmt"
-	"github.com/MarkusJx/traefik-wol/wol"
 	"net"
 	"net/http"
 	"sync"
 	"text/template"
 	"time"
+
+	"github.com/MarkusJx/traefik-wol/wol"
 )
 
 // Config the plugin configuration.
@@ -217,7 +218,12 @@ func (a *Wol) wakeUp() error {
 		}
 	}
 
-	bcastAddr := fmt.Sprintf("%s:%s", "255.255.255.255", "9")
+	targetIP := "255.255.255.255"
+	if len(a.ipAddress) > 0 {
+		targetIP = a.ipAddress
+	}
+
+	bcastAddr := fmt.Sprintf("%s:%s", targetIP, "9")
 	udpAddr, err := net.ResolveUDPAddr("udp", bcastAddr)
 	if err != nil {
 		return err

--- a/wol.go
+++ b/wol.go
@@ -70,12 +70,8 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 		return nil, fmt.Errorf("healthCheck cannot be empty")
 	}
 
-	if len(config.MacAddress) > 0 && len(config.IpAddress) == 0 || len(config.MacAddress) == 0 && len(config.IpAddress) > 0 {
-		return nil, fmt.Errorf("if mac or ip is set, the other must be set too")
-	}
-
-	if len(config.MacAddress) == 0 && len(config.IpAddress) == 0 && len(config.StartUrl) == 0 {
-		return nil, fmt.Errorf("either mac and ip or startUrl must be set")
+	if len(config.MacAddress) == 0 && len(config.StartUrl) == 0 {
+		return nil, fmt.Errorf("either mac or startUrl must be set")
 	}
 
 	if len(config.StartUrl) > 0 && len(config.MacAddress) > 0 {


### PR DESCRIPTION
I changed the behaviour of the ipAddress configuration, as it wasn't currently used.  
When the ipAddress is set, the magic packet is treated as subnet directed broadcasts.
This means, if your router/firewall is configured to allow this, you can either specify a subnet broadcast, or the router/firewall to deliver the magic packet over Layer3.

I tested the changes with traefik as ingress in kubernetes with a vyos router as wol-replay and a hp elitedesk.

This PR would also include the functionality of #9, but not adding another configuration setting.
The awful hack checking the length of the ipAddress from my code should propably be fixed:
```
targetIP := "255.255.255.255"
if len(a.ipAddress) > 0 {
  targetIP = a.ipAddress
}
```

I added the necessary documentation. I hope it is understandable.